### PR TITLE
Improved UI in DocumentModal for emails and iMessage chat transcripts

### DIFF
--- a/network-ui/src/components/DocumentModal.tsx
+++ b/network-ui/src/components/DocumentModal.tsx
@@ -1,6 +1,8 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { fetchDocument, fetchDocumentText } from '../api';
 import type { Document } from '../types';
+import { ImessageChatView, parseImessageTranscript } from './ImessageChatView';
+import { EmailThreadView, parseEmailThread } from './EmailThreadView';
 
 interface DocumentModalProps {
   docId: string;
@@ -16,14 +18,33 @@ interface MatchPosition {
   percentage: number;
 }
 
+type TranscriptView = 'chat' | 'email' | 'text';
+
 export default function DocumentModal({ docId, highlightTerm, secondaryHighlightTerm, onClose }: DocumentModalProps) {
   const [document, setDocument] = useState<Document | null>(null);
   const [documentText, setDocumentText] = useState<string>('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [matchPositions, setMatchPositions] = useState<MatchPosition[]>([]);
+  const [activeView, setActiveView] = useState<TranscriptView>('text');
   const contentRef = useRef<HTMLDivElement>(null);
   const matchRefs = useRef<Map<number, HTMLElement>>(new Map());
+  const imessageTranscript = useMemo(() => parseImessageTranscript(documentText), [documentText]);
+  const emailThread = useMemo(() => parseEmailThread(documentText), [documentText]);
+  const hasStructuredView = Boolean(imessageTranscript || emailThread);
+  const showChatView = Boolean(imessageTranscript && activeView === 'chat');
+  const showEmailView = Boolean(emailThread && activeView === 'email');
+  const showPlainTextView = !hasStructuredView || activeView === 'text';
+
+  useEffect(() => {
+    if (imessageTranscript) {
+      setActiveView('chat');
+    } else if (emailThread) {
+      setActiveView('email');
+    } else {
+      setActiveView('text');
+    }
+  }, [imessageTranscript, emailThread]);
 
   useEffect(() => {
     const loadDocument = async () => {
@@ -262,16 +283,67 @@ export default function DocumentModal({ docId, highlightTerm, secondaryHighlight
           )}
 
           {!loading && !error && documentText && (
-            <div className="prose prose-invert max-w-none">
-              <div className="whitespace-pre-wrap text-gray-300 leading-relaxed font-mono text-sm">
-                {highlightText(documentText, highlightTerm, secondaryHighlightTerm || null)}
-              </div>
+            <div className="space-y-6">
+              {hasStructuredView && (
+                <div>
+                  <div className="flex gap-4 border-b border-gray-700 mb-4">
+                    {imessageTranscript && (
+                      <button
+                        onClick={() => setActiveView('chat')}
+                        className={`pb-2 text-sm font-medium transition-colors ${
+                          showChatView
+                            ? 'text-blue-300 border-b-2 border-blue-400'
+                            : 'text-gray-500 border-b-2 border-transparent hover:text-gray-300'
+                        }`}
+                      >
+                        Chat View
+                      </button>
+                    )}
+                    {emailThread && (
+                      <button
+                        onClick={() => setActiveView('email')}
+                        className={`pb-2 text-sm font-medium transition-colors ${
+                          showEmailView
+                            ? 'text-blue-300 border-b-2 border-blue-400'
+                            : 'text-gray-500 border-b-2 border-transparent hover:text-gray-300'
+                        }`}
+                      >
+                        Email View
+                      </button>
+                    )}
+                    <button
+                      onClick={() => setActiveView('text')}
+                      className={`pb-2 text-sm font-medium transition-colors ${
+                        activeView === 'text'
+                          ? 'text-blue-300 border-b-2 border-blue-400'
+                          : 'text-gray-500 border-b-2 border-transparent hover:text-gray-300'
+                      }`}
+                    >
+                      Plain Text
+                    </button>
+                  </div>
+
+                  {showChatView && imessageTranscript && (
+                    <ImessageChatView transcript={imessageTranscript} />
+                  )}
+
+                  {showEmailView && emailThread && <EmailThreadView thread={emailThread} />}
+                </div>
+              )}
+
+              {showPlainTextView && (
+                <div className="prose prose-invert max-w-none">
+                  <div className="whitespace-pre-wrap text-gray-300 leading-relaxed font-mono text-sm">
+                    {highlightText(documentText, highlightTerm, secondaryHighlightTerm || null)}
+                  </div>
+                </div>
+              )}
             </div>
           )}
         </div>
 
         {/* Scroll Indicator - Fixed to modal container */}
-        {!loading && !error && matchPositions.length > 0 && (
+        {!loading && !error && matchPositions.length > 0 && showPlainTextView && (
           <div className="absolute right-4 top-32 bottom-24 w-3 bg-gray-700/50 rounded-full pointer-events-none z-10">
             {matchPositions.map((match, idx) => (
               <button

--- a/network-ui/src/components/EmailThreadView.tsx
+++ b/network-ui/src/components/EmailThreadView.tsx
@@ -1,0 +1,234 @@
+import { LinkifiedText } from './LinkifiedText';
+
+export interface EmailMessage {
+  from?: string;
+  to?: string;
+  cc?: string;
+  sent?: string;
+  subject?: string;
+  importance?: string;
+  headerLine?: string;
+  body: string;
+  isQuoted: boolean;
+}
+
+export interface EmailThread {
+  messages: EmailMessage[];
+  disclaimer?: string;
+}
+
+const headerRegex = /^(From|Sent|To|Subject|Cc|Bcc|Date|Importance):\s*(.*)$/i;
+const quotedRegex = /^On .+wrote:?$/i;
+const oversightLineRegex = /^HOUSE\s+OVERSIGHT\s+\d+/i;
+const disclaimerStartRegex = /^\s*please note\s*$/i;
+const disclaimerEndRegex = /attachments\. copyright/i;
+
+const parseHeaderValue = (line: string) => {
+  const match = line.match(headerRegex);
+  if (!match) return null;
+  return {
+    key: match[1].toLowerCase(),
+    value: match[2].trim()
+  };
+};
+
+const hasEmailStructure = (text: string) => {
+  const headerMatches = text.match(/^(From|Sent|To|Subject|Date):/gim);
+  return !!(headerMatches && headerMatches.length >= 2);
+};
+
+const extractDisclaimer = (lines: string[]): { disclaimer?: string; cleanedLines: string[] } => {
+  const cleaned: string[] = [];
+  let capturingDisclaimer = false;
+  let disclaimerLines: string[] = [];
+
+  for (const line of lines) {
+    if (oversightLineRegex.test(line.trim())) {
+      continue;
+    }
+
+    if (disclaimerStartRegex.test(line)) {
+      capturingDisclaimer = true;
+      disclaimerLines.push(line);
+      continue;
+    }
+
+    if (capturingDisclaimer) {
+      disclaimerLines.push(line);
+      if (disclaimerEndRegex.test(line)) {
+        capturingDisclaimer = false;
+      }
+      continue;
+    }
+
+    cleaned.push(line);
+  }
+
+  return {
+    disclaimer: disclaimerLines.length > 0 ? disclaimerLines.join('\n').trim() : undefined,
+    cleanedLines: cleaned
+  };
+};
+
+export const parseEmailThread = (rawText: string): EmailThread | null => {
+  if (!rawText || !hasEmailStructure(rawText)) {
+    return null;
+  }
+
+  const { cleanedLines, disclaimer } = extractDisclaimer(rawText.split(/\r?\n/));
+  const lines = cleanedLines;
+
+  const messages: EmailMessage[] = [];
+  let index = 0;
+
+  const collectBody = () => {
+    const bodyLines: string[] = [];
+    while (
+      index < lines.length &&
+      !quotedRegex.test(lines[index].trim()) &&
+      !headerRegex.test(lines[index])
+    ) {
+      bodyLines.push(lines[index]);
+      index++;
+    }
+    return bodyLines.join('\n').trim();
+  };
+
+  while (index < lines.length) {
+    const line = lines[index];
+    const trimmed = line.trim();
+
+    if (!trimmed) {
+      index++;
+      continue;
+    }
+
+    if (quotedRegex.test(trimmed)) {
+      const headerLine = trimmed;
+      index++;
+      const body = collectBody();
+      messages.push({
+        headerLine,
+        body,
+        isQuoted: true
+      });
+      continue;
+    }
+
+    if (!headerRegex.test(line)) {
+      index++;
+      continue;
+    }
+
+    const headers: Record<string, string> = {};
+    while (index < lines.length) {
+      const parsed = parseHeaderValue(lines[index]);
+      if (!parsed) break;
+      headers[parsed.key] = parsed.value;
+      index++;
+    }
+
+    while (index < lines.length && lines[index].trim() === '') {
+      index++;
+    }
+
+    const body = collectBody();
+
+    messages.push({
+      from: headers['from'],
+      to: headers['to'],
+      cc: headers['cc'] || headers['bcc'],
+      sent: headers['sent'] || headers['date'],
+      subject: headers['subject'],
+      importance: headers['importance'],
+      body,
+      isQuoted: false
+    });
+  }
+
+  if (messages.length === 0) {
+    return null;
+  }
+
+  return { messages, disclaimer };
+};
+
+interface EmailThreadViewProps {
+  thread: EmailThread;
+}
+
+export function EmailThreadView({ thread }: EmailThreadViewProps) {
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-yellow-800/50 bg-yellow-900/10 text-sm text-yellow-100 p-3">
+        Rendering of emails is best-effort because the source text is inconsistent. Always double-check against the plain text view before quoting or jumping to conclusions.
+      </div>
+
+      {thread.messages.map((message, idx) => (
+        <div
+          key={`${message.sent ?? idx}-${idx}`}
+          className={`rounded-2xl border border-gray-700/60 p-4 ${
+            message.isQuoted ? 'bg-gray-800/40' : 'bg-gray-800/70'
+          }`}
+        >
+          {!message.isQuoted ? (
+            <div className="space-y-1 text-sm text-gray-300">
+              {message.subject && (
+                <div className="text-lg font-semibold text-white">{message.subject}</div>
+              )}
+              {message.from && (
+                <div>
+                  <span className="text-gray-500 uppercase tracking-wider text-xs">From: </span>
+                  {message.from}
+                </div>
+              )}
+              {message.to && (
+                <div>
+                  <span className="text-gray-500 uppercase tracking-wider text-xs">To: </span>
+                  {message.to}
+                </div>
+              )}
+              {message.cc && (
+                <div>
+                  <span className="text-gray-500 uppercase tracking-wider text-xs">Cc: </span>
+                  {message.cc}
+                </div>
+              )}
+              {message.sent && (
+                <div>
+                  <span className="text-gray-500 uppercase tracking-wider text-xs">Sent: </span>
+                  {message.sent}
+                </div>
+              )}
+              {message.importance && (
+                <div>
+                  <span className="text-gray-500 uppercase tracking-wider text-xs">Importance: </span>
+                  {message.importance}
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="text-sm text-gray-400 italic">{message.headerLine}</div>
+          )}
+
+          {message.body && (
+            <div className="mt-3 whitespace-pre-wrap text-sm text-gray-100 leading-relaxed">
+              <LinkifiedText text={message.body} />
+            </div>
+          )}
+        </div>
+      ))}
+
+      {thread.disclaimer && (
+        <details className="rounded-lg border border-gray-700/60 bg-gray-800/50">
+          <summary className="px-4 py-2 cursor-pointer text-sm text-gray-200">
+            View disclaimer
+          </summary>
+          <div className="px-4 pb-4 pt-2 whitespace-pre-wrap text-xs text-gray-400 leading-relaxed">
+            {thread.disclaimer}
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/network-ui/src/components/ImessageChatView.tsx
+++ b/network-ui/src/components/ImessageChatView.tsx
@@ -1,0 +1,227 @@
+import { useMemo } from 'react';
+import { LinkifiedText } from './LinkifiedText';
+
+export interface ImessageMessage {
+  sender: string;
+  displayName: string;
+  time?: string;
+  message: string;
+  isLocal: boolean;
+}
+
+export interface ImessageTranscript {
+  participants: string[];
+  presentityIds: string[];
+  messages: ImessageMessage[];
+}
+
+const metadataRegex = /^(Flags|Is Read|Is Invitation|GUID|Last Message ID|Source|Service|Start Time|End Time|Chat Room|Messages\s*-?)/i;
+const participantsRegex = /^Participants:/i;
+const presentityRegex = /^Presentity IDs:/i;
+const senderRegex = /^Sender:/i;
+const timeRegex = /^Time:/i;
+const messageRegex = /^Message:/i;
+const sectionBreakRegex = /^(HOUSE\s+OVERSIGHT|[-A-Z0-9_ ]{5,}\d{3,})/;
+const PRIMARY_SENDER_EMAIL = 'jeeitunes@gmail.com';
+
+const parseListField = (value: string) =>
+  value
+    .split(/[,;]+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+const extractValue = (line: string) => line.slice(line.indexOf(':') + 1).trim();
+
+const cleanIdentifier = (value: string) => value.replace(/^e:/i, '').trim();
+
+interface RawMessageState {
+  sender?: string;
+  time?: string;
+  messageParts: string[];
+  capturing: boolean;
+}
+
+const finalizeMessage = (
+  current: RawMessageState | null,
+  fallbackLocalName: string
+): ImessageMessage | null => {
+  if (!current) return null;
+  const combinedMessage = current.messageParts.join('\n').trim();
+  if (!combinedMessage) {
+    return null;
+  }
+
+  const rawSender = current.sender ? cleanIdentifier(current.sender) : '';
+  const senderLower = rawSender.toLowerCase();
+  const normalizedPrimary = PRIMARY_SENDER_EMAIL.toLowerCase();
+  const isLocal = senderLower === normalizedPrimary;
+  const displayName = rawSender || (isLocal ? fallbackLocalName : 'Unknown');
+  const cleanedTime = current.time ? current.time.split('(')[0]?.trim() : undefined;
+
+  return {
+    sender: rawSender || displayName,
+    displayName,
+    time: cleanedTime,
+    message: combinedMessage,
+    isLocal
+  };
+};
+
+export const parseImessageTranscript = (text: string): ImessageTranscript | null => {
+  if (!text || !text.includes('Service: iMessage')) {
+    return null;
+  }
+
+  const lines = text.split(/\r?\n/);
+  let participants: string[] = [];
+  let presentityIds: string[] = [];
+  const messages: ImessageMessage[] = [];
+
+  let current: RawMessageState | null = null;
+
+  const pushCurrentMessage = () => {
+    const fallbackLocalName =
+      presentityIds.find(Boolean) || participants.find(Boolean) || PRIMARY_SENDER_EMAIL;
+    const parsed = finalizeMessage(current, fallbackLocalName);
+    if (parsed) {
+      messages.push(parsed);
+    }
+    current = null;
+  };
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (!trimmed) {
+      if (current?.capturing) {
+        current.messageParts.push('');
+      }
+      continue;
+    }
+
+    if (participantsRegex.test(trimmed)) {
+      participants = parseListField(extractValue(line)).map(cleanIdentifier);
+      continue;
+    }
+
+    if (presentityRegex.test(trimmed)) {
+      presentityIds = parseListField(extractValue(line)).map(cleanIdentifier);
+      continue;
+    }
+
+    if (sectionBreakRegex.test(trimmed)) {
+      if (current) {
+        current.capturing = false;
+      }
+      continue;
+    }
+
+    if (senderRegex.test(trimmed)) {
+      if (current) {
+        pushCurrentMessage();
+      }
+      current = {
+        sender: extractValue(line),
+        time: undefined,
+        messageParts: [],
+        capturing: false
+      };
+      continue;
+    }
+
+    if (timeRegex.test(trimmed)) {
+      if (!current) {
+        current = { messageParts: [], capturing: false };
+      }
+      current.time = extractValue(line);
+      continue;
+    }
+
+    if (messageRegex.test(trimmed)) {
+      if (!current) {
+        current = { messageParts: [], capturing: true };
+      }
+      const initial = extractValue(line);
+      current.messageParts = initial ? [initial] : [];
+      current.capturing = true;
+      continue;
+    }
+
+    if (metadataRegex.test(trimmed)) {
+      if (current) {
+        current.capturing = false;
+      }
+      continue;
+    }
+
+    if (current?.capturing) {
+      current.messageParts.push(line);
+    }
+  }
+
+  if (current) {
+    pushCurrentMessage();
+  }
+
+  if (messages.length === 0) {
+    return null;
+  }
+
+  return {
+    participants,
+    presentityIds,
+    messages
+  };
+};
+
+interface ImessageChatViewProps {
+  transcript: ImessageTranscript;
+}
+
+export function ImessageChatView({ transcript }: ImessageChatViewProps) {
+  const participantNames = useMemo(() => {
+    return Array.from(
+      new Set([...transcript.participants, ...transcript.presentityIds])
+    ).filter(Boolean);
+  }, [transcript]);
+
+  return (
+    <div className="space-y-6">
+      <div className="text-sm text-gray-400">
+        Participants:{' '}
+        <span className="text-gray-200">
+          {participantNames.length > 0 ? participantNames.join(', ') : 'Unknown'}
+        </span>
+      </div>
+
+      <div className="space-y-4">
+        {transcript.messages.map((message, idx) => (
+          <div
+            key={`${message.displayName}-${idx}-${message.time ?? ''}`}
+            className={`flex ${message.isLocal ? 'justify-end' : 'justify-start'}`}
+          >
+            <div className="max-w-[80%]">
+              <div
+                className={`text-xs text-gray-500 mb-1 ${
+                  message.isLocal ? 'text-right' : 'text-left'
+                }`}
+              >
+                {message.displayName}
+                {message.time ? ` • ${message.time}` : ''}
+              </div>
+              <div
+                className={`px-4 py-2 whitespace-pre-wrap leading-relaxed text-sm shadow-lg ${
+                  message.isLocal
+                    ? 'bg-blue-500 text-white rounded-2xl rounded-br-sm'
+                    : 'bg-gray-700 text-gray-100 rounded-2xl rounded-bl-sm'
+                }`}
+              >
+                <LinkifiedText text={message.message} />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/network-ui/src/components/LinkifiedText.tsx
+++ b/network-ui/src/components/LinkifiedText.tsx
@@ -1,0 +1,82 @@
+import type { ReactNode } from 'react';
+
+interface LinkifiedTextProps {
+  text: string;
+}
+
+const isLinkStart = (value: string, index: number) => {
+  const lower = value.toLowerCase();
+  const httpIndex = lower.indexOf('http://', index);
+  const httpsIndex = lower.indexOf('https://', index);
+
+  if (httpIndex === -1) return httpsIndex;
+  if (httpsIndex === -1) return httpIndex;
+  return Math.min(httpIndex, httpsIndex);
+};
+
+const renderLinkifiedContent = (text: string): ReactNode[] => {
+  const nodes: ReactNode[] = [];
+  let cursor = 0;
+  let key = 0;
+
+  const pushText = (value: string) => {
+    if (!value) return;
+    nodes.push(
+      <span key={`text-${key++}`}>
+        {value}
+      </span>
+    );
+  };
+
+  while (cursor < text.length) {
+    const nextLink = isLinkStart(text, cursor);
+    if (nextLink === -1) {
+      pushText(text.slice(cursor));
+      break;
+    }
+
+    if (nextLink > cursor) {
+      pushText(text.slice(cursor, nextLink));
+    }
+
+    let end = nextLink;
+    while (end < text.length) {
+      const char = text[end];
+      if (char === '\n' || char === '\r') {
+        end++;
+        continue;
+      }
+      if (char === ')' || /\s/.test(char)) {
+        break;
+      }
+      end++;
+    }
+
+    const displayUrl = text.slice(nextLink, end);
+    const href = displayUrl.replace(/\s+/g, '');
+
+    nodes.push(
+      <a
+        key={`link-${key++}`}
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline text-blue-200 hover:text-blue-100 break-all"
+      >
+        {displayUrl}
+      </a>
+    );
+
+    cursor = end;
+  }
+
+  return nodes;
+};
+
+export function LinkifiedText({ text }: LinkifiedTextProps) {
+  const nodes = renderLinkifiedContent(text);
+  if (nodes.length === 0) {
+    return <>{text}</>;
+  }
+  return <>{nodes}</>;
+}


### PR DESCRIPTION
I forked and made a few improvements for display of emails and chat transcripts, in case you want to consider it for the main repo. (implementation by Codex) 

- Chat transcript rendering: added dedicated ImessageChatView component with improved parser that tags jeeitunes@gmail.com as the only “local” sender (right/blue), renders everyone else left/gray, and linkifies URLs (including multi-line) via shared LinkifiedText.
- Enhanced modal UX: introduced structured tabs for iMessage Chat, Email, and Plain Text; plain-text highlighting/scroll indicator remain tied to the plain-text tab.
- Added email thread support: best-effort parser detects headers/quoted replies, strips HOUSE OVERSIGHT ###### lines, extracts/common disclaimer blocks, and renders emails in card-like view with caution banner and collapsible disclaimer. Links in emails are clickable via LinkifiedText.
- Shared utilities: LinkifiedText handles newline-preserving clickable URLs for both chat and email views.